### PR TITLE
chore: fix dependabot config and update terraform-docs version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
   # Maintain dependencies for Terraform
   - package-ecosystem: "terraform"
     directories:
-      - "/modules/**/*"
+      - "/"
+      - "/examples/**/*"
     schedule:
       interval: "monthly"

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -6,7 +6,7 @@ on:
       - main
 
 env:
-  TERRAFORM_DOCS_VERSION: v0.18.0
+  TERRAFORM_DOCS_VERSION: v0.19.0
   TFLINT_VERSION: v0.54.0
 
 jobs:


### PR DESCRIPTION
This pull request includes updates to the configuration files related to dependency management and workflow automation. The most important changes include modifying the directories monitored for Terraform dependencies and updating the Terraform Docs version used in the pre-commit workflow.

Updates to dependency management:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L12-R13): Expanded the directories monitored for Terraform dependencies to include the root directory and the `examples` directory.

Workflow automation:

* [`.github/workflows/pre-commit.yml`](diffhunk://#diff-ac5eead3f3ce4863c524fff031a87b7aecccb4a0493df087a4e1c704a1505036L9-R9): Updated the `TERRAFORM_DOCS_VERSION` environment variable from v0.18.0 to v0.19.0.