### PR TITLE
docs: improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,38 @@ The module follows the same structure as the [Terraform AWS community modules](h
 ## Usage
 
 ```hcl
+module "knowledge_base" {
+  source = "github.com/wolfm89/terraform-aws-bedrock-knowledge-base"
 
+  name            = "knowledge-base"
+  embedding_model = "amazon.titan-embed-text-v2:0"
+
+  storage_type = "OPENSEARCH_SERVERLESS"
+  opensearch_serverless_config = {
+    collection_arn    = "arn:aws:aoss:eu-central-1:123456789012:collection/w3vefn2ijps5xj0j9x6f"
+    vector_index_name = "knowledge-base-index"
+    field_mapping = {
+      vector_field   = "vector"
+      metadata_field = "metadata"
+      text_field     = "text"
+    }
+  }
+
+  data_source_configurations = {
+    "source1" = {
+      bucket                   = "my-bucket"
+      bucket_paths             = ["source1"]
+      chunking_strategy        = "FIXED_SIZE"
+      fixed_max_tokens         = 300
+      fixed_overlap_percentage = 10
+    }
+  }
+}
 ```
 
 ## Examples
 
-- [](./examples//README.md):
+- [Knowledge Base with OpenSearch](./examples/oss-complete/README.md)
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
@@ -60,7 +86,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_data_source_configurations"></a> [data\_source\_configurations](#input\_data\_source\_configurations) | Configuration for the data source | <pre>map(object({<br/>    bucket                                   = string<br/>    bucket_paths                             = list(string)<br/>    chunking_strategy                        = optional(string, "NONE")<br/>    fixed_max_tokens                         = optional(number, null)<br/>    fixed_overlap_percentage                 = optional(number, null)<br/>    hierarchical_level_parent_max_tokens     = optional(number, null)<br/>    hierarchical_level_child_max_tokens      = optional(number, null)<br/>    hierarchical_overlap_tokens              = optional(number, null)<br/>    semantic_breakpoint_percentile_threshold = optional(number, null)<br/>    semantic_buffer_size                     = optional(number, null)<br/>    semantic_max_tokens                      = optional(number, null)<br/>    parsing_model_arn                        = optional(string, null)<br/>    parsing_prompt_string                    = optional(string, null)<br/>  }))</pre> | n/a | yes |
+| <a name="input_data_source_configurations"></a> [data\_source\_configurations](#input\_data\_source\_configurations) | Configurations for the data sources | <pre>map(object({<br/>    bucket                                   = string<br/>    bucket_paths                             = list(string)<br/>    chunking_strategy                        = optional(string, "NONE")<br/>    fixed_max_tokens                         = optional(number, null)<br/>    fixed_overlap_percentage                 = optional(number, null)<br/>    hierarchical_level_parent_max_tokens     = optional(number, null)<br/>    hierarchical_level_child_max_tokens      = optional(number, null)<br/>    hierarchical_overlap_tokens              = optional(number, null)<br/>    semantic_breakpoint_percentile_threshold = optional(number, null)<br/>    semantic_buffer_size                     = optional(number, null)<br/>    semantic_max_tokens                      = optional(number, null)<br/>    parsing_model_arn                        = optional(string, null)<br/>    parsing_prompt_string                    = optional(string, null)<br/>  }))</pre> | n/a | yes |
 | <a name="input_embedding_model"></a> [embedding\_model](#input\_embedding\_model) | Name of the embedding model | `string` | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | Name of the knowledge base | `string` | n/a | yes |
 | <a name="input_opensearch_serverless_config"></a> [opensearch\_serverless\_config](#input\_opensearch\_serverless\_config) | Configuration for OpenSearch Serverless | <pre>object({<br/>    collection_arn    = string<br/>    vector_index_name = string<br/>    field_mapping = object({<br/>      vector_field   = string<br/>      text_field     = string<br/>      metadata_field = string<br/>    })<br/>  })</pre> | `null` | no |
@@ -73,6 +99,6 @@ No modules.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_data_source_ids"></a> [data\_source\_ids](#output\_data\_source\_ids) | Map of data source name to ID. |
-| <a name="output_knowledge_base_id"></a> [knowledge\_base\_id](#output\_knowledge\_base\_id) | The ID of the knowledge base. |
+| <a name="output_data_source_ids"></a> [data\_source\_ids](#output\_data\_source\_ids) | Map of data source name to ID |
+| <a name="output_knowledge_base_id"></a> [knowledge\_base\_id](#output\_knowledge\_base\_id) | ID of the knowledge base |
 <!-- END_TF_DOCS -->

--- a/examples/oss-complete/README.md
+++ b/examples/oss-complete/README.md
@@ -19,7 +19,7 @@ This will be used to configure the S3 backend for Terraform.
 Create a file named `terraform.tfvars` with the following content (replace the values with your own):
 
 ```hcl
-creator                          = "my.email@email.com"
+creator = "my.email@email.com"
 ```
 
 To run this example you need to execute:
@@ -77,7 +77,7 @@ Note that this example may create resources which can cost money. Run `terraform
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_creator"></a> [creator](#input\_creator) | The creator of the resources. Used for resource tagging. | `string` | n/a | yes |
+| <a name="input_creator"></a> [creator](#input\_creator) | Creator of the resources. Used for resource tagging | `string` | n/a | yes |
 
 ## Outputs
 

--- a/examples/oss-complete/variables.tf
+++ b/examples/oss-complete/variables.tf
@@ -1,5 +1,5 @@
 variable "creator" {
   nullable    = false
   type        = string
-  description = "The creator of the resources. Used for resource tagging."
+  description = "Creator of the resources. Used for resource tagging"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,9 +1,9 @@
 output "knowledge_base_id" {
-  description = "The ID of the knowledge base."
+  description = "ID of the knowledge base"
   value       = aws_bedrockagent_knowledge_base.kb.id
 }
 
 output "data_source_ids" {
-  description = "Map of data source name to ID."
+  description = "Map of data source name to ID"
   value       = { for k, v in aws_bedrockagent_data_source.data_source : k => v.data_source_id }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -103,7 +103,7 @@ variable "rds_config" {
   }
 }
 variable "data_source_configurations" {
-  description = "Configuration for the data source"
+  description = "Configurations for the data sources"
   type = map(object({
     bucket                                   = string
     bucket_paths                             = list(string)


### PR DESCRIPTION
This pull request includes updates to the `README.md`, `variables.tf`, and `outputs.tf` files to enhance the documentation and configuration descriptions for the Terraform AWS module. The most important changes include adding a usage example for the knowledge base module, updating descriptions for various configuration fields, and modifying output descriptions.

Enhancements to documentation and usage examples:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L9-R40): Added a detailed usage example for the `knowledge_base` module, including configuration for `embedding_model`, `storage_type`, `opensearch_serverless_config`, and `data_source_configurations`.

Updates to configuration descriptions:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L63-R89): Updated the description for `data_source_configurations` to clarify that it includes multiple data sources.
* [`variables.tf`](diffhunk://#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288eL106-R106): Modified the description for `data_source_configurations` to reflect that it includes configurations for multiple data sources.

Improvements to output descriptions:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L76-R103): Simplified the descriptions for `data_source_ids` and `knowledge_base_id` outputs.
* [`outputs.tf`](diffhunk://#diff-de6c47c2496bd028a84d55ab12d8a4f90174ebfb6544b8b5c7b07a7ee4f27ec7L2-R7): Updated the descriptions for `knowledge_base_id` and `data_source_ids` outputs to be more concise.

Consistency in variable descriptions:

* [`examples/oss-complete/README.md`](diffhunk://#diff-22f732de5b37a5020d3b3adfbb51b58b94d415e887bdd032a27adb12b88d3cf5L80-R80): Simplified the description for the `creator` input variable.
* [`examples/oss-complete/variables.tf`](diffhunk://#diff-927797fc01c05018fdccc4f485f700a750b9d5ab2433ebfe4273c681bbb33dbaL4-R4): Updated the description for the `creator` variable to match the simplified format.